### PR TITLE
Add Qwen 2.5 1.5B to benchmark suite

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,6 +24,10 @@ LLAMA_8B_TP := "1"
 LLAMA_3B_PATH := "neuralmagic/Llama-3.2-3B-Instruct-FP8"
 LLAMA_3B_TP := "1"
 
+QWEN_1_5B_PATH := "Qwen/Qwen2.5-1.5B-Instruct"
+QWEN_1_5B_TP := "1"
+
+
 # Port configurations
 VLLM_PORT := "8000"
 SGL_PORT := "30000"
@@ -80,8 +84,11 @@ get-model-path model:
         "llama-3b")
             echo {{LLAMA_3B_PATH}}
             ;;
+        "qwen-1.5b")
+            echo {{QWEN_1_5B_PATH}}
+            ;;
         *)
-            echo "Invalid model. Available models: deepseek-r1, qwq-32b, llama-8b, llama-3b" >&2
+            echo "Invalid model. Available models: deepseek-r1, qwq-32b, llama-8b, llama-3b, qwen-1.5b" >&2
             exit 1
             ;;
     esac
@@ -123,7 +130,7 @@ clone-vllm-benchmarks target_dir="vllm-benchmarks":
   #!/usr/bin/env bash
   set -euo pipefail
   rm -rf {{target_dir}}
-  git clone --filter=blob:none --no-checkout https://github.com/vllm-project/vllm.git {{target_dir}}
+  git clone https://github.com/vllm-project/vllm.git {{target_dir}}
   cd {{target_dir}}
   git sparse-checkout init --no-cone
   echo "benchmarks/**" > .git/info/sparse-checkout
@@ -171,7 +178,7 @@ run-scenario backend="vllm" model="deepseek-r1" lengths="1000,1000":
 # Run benchmark sweeps for a specific backend and model
 run-sweeps backend="vllm" model="deepseek-r1":
   #!/usr/bin/env bash
-  for pair in "1000,2000" "5000,1000" "10000,500" "32000,100"; do
+  for pair in "1000,2000" "5000,1000" "10000,500" "30000,100"; do
     just run-scenario {{backend}} {{model}} ${pair}
   done
 

--- a/Justfile
+++ b/Justfile
@@ -27,7 +27,6 @@ LLAMA_3B_TP := "1"
 QWEN_1_5B_PATH := "Qwen/Qwen2.5-1.5B-Instruct"
 QWEN_1_5B_TP := "1"
 
-
 # Port configurations
 VLLM_PORT := "8000"
 SGL_PORT := "30000"
@@ -130,7 +129,7 @@ clone-vllm-benchmarks target_dir="vllm-benchmarks":
   #!/usr/bin/env bash
   set -euo pipefail
   rm -rf {{target_dir}}
-  git clone https://github.com/vllm-project/vllm.git {{target_dir}}
+  git clone --filter=blob:none --no-checkout https://github.com/vllm-project/vllm.git {{target_dir}}
   cd {{target_dir}}
   git sparse-checkout init --no-cone
   echo "benchmarks/**" > .git/info/sparse-checkout

--- a/extract-result.py
+++ b/extract-result.py
@@ -90,15 +90,16 @@ def calculate_comparison(df):
         vllm_data = group[group['backend'] == 'vllm'].iloc[0] if len(group[group['backend'] == 'vllm']) > 0 else None
         sgl_data = group[group['backend'] == 'sgl'].iloc[0] if len(group[group['backend'] == 'sgl']) > 0 else None
 
-        if vllm_data is not None and sgl_data is not None:
-            for metric in metrics:
-                vllm_value = vllm_data[metric]
-                sgl_value = sgl_data[metric]
-                gap_percentage = ((vllm_value - sgl_value) / sgl_value) * 100
+        for metric in metrics:
+            vllm_value = vllm_data[metric] if vllm_data is not None else 0
+            sgl_value = sgl_data[metric] if sgl_data is not None else 0
 
-                scenario[f'vllm_{metric}'] = vllm_value
-                scenario[f'sgl_{metric}'] = sgl_value
-                scenario[f'gap_{metric}'] = gap_percentage
+            # Calculate gap percentage only if both values are non-zero
+            gap_percentage = ((vllm_value - sgl_value) / sgl_value * 100) if sgl_value != 0 else 0
+
+            scenario[f'vllm_{metric}'] = vllm_value
+            scenario[f'sgl_{metric}'] = sgl_value
+            scenario[f'gap_{metric}'] = gap_percentage
 
         scenarios.append(scenario)
 


### PR DESCRIPTION
1. Add Qwen 2.5 1.5B to suite to represent smaller models and also Qwen model family
2. Adjust 32k input -> 30k input since 32k benchmark hits Qwen context limit
3. Adjust results logic to show results for an engine even if other engine results are not available

Tested this locally on A100, but haven't run full suite in README since i don't have H200 right now.

```
     Benchmark Comparison: vLLM vs SGL (Output Tokens/s)     
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┓
┃ Input Tokens ┃ Output Tokens ┃    vLLM ┃     SGL ┃ Diff % ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━┩
│         1000 │          2000 │ 2194.54 │ 6305.02 │ -65.2% │
│         5000 │          1000 │ 2143.13 │ 3520.48 │ -39.1% │
│        10000 │           500 │  945.44 │ 1405.00 │ -32.7% │
│        30000 │           100 │   70.30 │   98.92 │ -28.9% │
└──────────────┴───────────────┴─────────┴─────────┴────────┘
```